### PR TITLE
Unignores /static/app/ but ignores all its contents.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,3 @@ hs_err_pid*
 
 # Database
 *.db
-
-# Frontend generated code
-src/main/resources/static/app/

--- a/src/main/resources/static/app/.gitignore
+++ b/src/main/resources/static/app/.gitignore
@@ -1,0 +1,4 @@
+# Ignore all contents in this folder
+*
+# But keep this file in .git
+!.gitignore


### PR DESCRIPTION
This makes sure the Core module will boot up when cloning an empty .git repository, but it will ignore all changes inside the folder.