### PR TITLE
Added user entity, fixes #113

### DIFF
--- a/src/main/java/me/moodcat/api/RoomAPI.java
+++ b/src/main/java/me/moodcat/api/RoomAPI.java
@@ -1,8 +1,17 @@
 package me.moodcat.api;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.stream.Collectors;
+import algorithms.KNearestNeighbours;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.inject.Inject;
+import com.google.inject.persist.Transactional;
+import datastructures.dataholders.Pair;
+import me.moodcat.database.controllers.ChatDAO;
+import me.moodcat.database.controllers.RoomDAO;
+import me.moodcat.database.embeddables.VAVector;
+import me.moodcat.database.entities.ChatMessage;
+import me.moodcat.database.entities.Room;
+import me.moodcat.database.entities.Room.RoomDistanceMetric;
+import me.moodcat.mood.Mood;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DefaultValue;
@@ -13,21 +22,9 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
-
-import me.moodcat.database.controllers.ChatDAO;
-import me.moodcat.database.controllers.RoomDAO;
-import me.moodcat.database.embeddables.VAVector;
-import me.moodcat.database.entities.ChatMessage;
-import me.moodcat.database.entities.Room;
-import me.moodcat.database.entities.Room.RoomDistanceMetric;
-import me.moodcat.mood.Mood;
-import algorithms.KNearestNeighbours;
-
-import com.google.common.annotations.VisibleForTesting;
-import com.google.inject.Inject;
-import com.google.inject.persist.Transactional;
-
-import datastructures.dataholders.Pair;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * The API for the room.

--- a/src/main/java/me/moodcat/database/controllers/UserDAO.java
+++ b/src/main/java/me/moodcat/database/controllers/UserDAO.java
@@ -12,26 +12,28 @@ import static me.moodcat.database.entities.QUser.user;
  */
 public class UserDAO extends AbstractDAO<User> {
 
-	/**
-	 * Construct a new user data access object.
-	 *
-	 * @param entityManager current entity manager
-	 */
-	@Inject
-	public UserDAO(final EntityManager entityManager) {
-		super(entityManager);
-	}
+    /**
+     * Construct a new user data access object.
+     *
+     * @param entityManager
+     *            current entity manager
+     */
+    @Inject
+    public UserDAO(final EntityManager entityManager) {
+        super(entityManager);
+    }
 
-	/**
-	 * Find a user by its soundcloud id.
-	 *
-	 * @param soundCloudId Soundcloud id for the user
-	 * @return The user entity
-	 */
-	public User retrieveBySoundcloudId(final Integer soundCloudId) {
-		return ensureExists(query().from(user)
-			.where(user.soundcloud_id.eq(soundCloudId))
-			.singleResult(user));
-	}
+    /**
+     * Find a user by its soundcloud id.
+     *
+     * @param soundCloudId
+     *            Soundcloud id for the user
+     * @return The user entity
+     */
+    public User retrieveBySoundcloudId(final Integer soundCloudId) {
+        return ensureExists(query().from(user)
+                .where(user.soundCloudUserId.eq(soundCloudId))
+                .singleResult(user));
+    }
 
 }

--- a/src/main/java/me/moodcat/database/controllers/UserDAO.java
+++ b/src/main/java/me/moodcat/database/controllers/UserDAO.java
@@ -1,0 +1,37 @@
+package me.moodcat.database.controllers;
+
+import me.moodcat.database.entities.User;
+
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+
+import static me.moodcat.database.entities.QUser.user;
+
+/**
+ * Data access object for user entities.
+ */
+public class UserDAO extends AbstractDAO<User> {
+
+	/**
+	 * Construct a new user data access object.
+	 *
+	 * @param entityManager current entity manager
+	 */
+	@Inject
+	public UserDAO(final EntityManager entityManager) {
+		super(entityManager);
+	}
+
+	/**
+	 * Find a user by its soundcloud id.
+	 *
+	 * @param soundCloudId Soundcloud id for the user
+	 * @return The user entity
+	 */
+	public User retrieveBySoundcloudId(final Integer soundCloudId) {
+		return ensureExists(query().from(user)
+			.where(user.soundcloud_id.eq(soundCloudId))
+			.singleResult(user));
+	}
+
+}

--- a/src/main/java/me/moodcat/database/entities/ChatMessage.java
+++ b/src/main/java/me/moodcat/database/entities/ChatMessage.java
@@ -24,7 +24,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 @Entity
 @Table(name = "chatmessage")
 @ToString(of = {
-        "room", "message", "author"
+        "room", "message", "user"
 })
 @EqualsAndHashCode(of = "id")
 @NoArgsConstructor()
@@ -60,9 +60,9 @@ public class ChatMessage {
      *            The author to set.
      * @return The author that made this chatmessage
      */
-    @Column(name = "author", nullable = false)
-    @NonNull
-    private String author;
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
 
     /**
      * The room the message was for.

--- a/src/main/java/me/moodcat/database/entities/User.java
+++ b/src/main/java/me/moodcat/database/entities/User.java
@@ -1,0 +1,67 @@
+package me.moodcat.database.entities;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import javax.persistence.Basic;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+/**
+ * User entity.
+ */
+@Data
+@Entity
+@Table(name = "user")
+@EqualsAndHashCode(of = {
+	"id"
+})
+public class User {
+
+	/**
+	 * The unique id of the user.
+	 *
+	 * @param id
+	 *            The new Id to set.
+	 * @return The id of the user.
+	 */
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "id", nullable = false)
+	private Integer id;
+
+	/**
+	 * The unique id of the user.
+	 *
+	 * @param id
+	 *            The new Id to set.
+	 * @return The id of the user.
+	 */
+	@Column(name = "soundcloud_id", nullable = true, unique = true)
+	private Integer soundcloud_id;
+
+	/**
+	 * The name of this user.
+	 *
+	 * @param name
+	 *            The name to set.
+	 * @return The name of this user.
+	 */
+	@Column(name = "name", nullable = false, unique = true)
+	private String name;
+
+	/**
+	 * Soundcloud OAuth access token.
+	 *
+	 * See: https://developers.soundcloud.com/docs/api/reference#token
+	 */
+	@Basic(fetch = FetchType.LAZY)
+	@Column(name = "access_token", nullable = true)
+	private String accessToken;
+
+}

--- a/src/main/java/me/moodcat/database/entities/User.java
+++ b/src/main/java/me/moodcat/database/entities/User.java
@@ -19,49 +19,48 @@ import javax.persistence.Table;
 @Entity
 @Table(name = "user")
 @EqualsAndHashCode(of = {
-	"id"
+        "id"
 })
 public class User {
 
-	/**
-	 * The unique id of the user.
-	 *
-	 * @param id
-	 *            The new Id to set.
-	 * @return The id of the user.
-	 */
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "id", nullable = false)
-	private Integer id;
+    /**
+     * The unique id of the user.
+     *
+     * @param id
+     *            The new Id to set.
+     * @return The id of the user.
+     */
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Integer id;
 
-	/**
-	 * The unique id of the user.
-	 *
-	 * @param id
-	 *            The new Id to set.
-	 * @return The id of the user.
-	 */
-	@Column(name = "soundcloud_id", nullable = true, unique = true)
-	private Integer soundcloud_id;
+    /**
+     * The unique id of the user.
+     *
+     * @param id
+     *            The new Id to set.
+     * @return The id of the user.
+     */
+    @Column(name = "soundCloudUserId", nullable = true, unique = true)
+    private Integer soundCloudUserId;
 
-	/**
-	 * The name of this user.
-	 *
-	 * @param name
-	 *            The name to set.
-	 * @return The name of this user.
-	 */
-	@Column(name = "name", nullable = false, unique = true)
-	private String name;
+    /**
+     * The name of this user.
+     *
+     * @param name
+     *            The name to set.
+     * @return The name of this user.
+     */
+    @Column(name = "name", nullable = false, unique = true)
+    private String name;
 
-	/**
-	 * Soundcloud OAuth access token.
-	 *
-	 * See: https://developers.soundcloud.com/docs/api/reference#token
-	 */
-	@Basic(fetch = FetchType.LAZY)
-	@Column(name = "access_token", nullable = true)
-	private String accessToken;
+    /**
+     * SoundCloud OAuth access token.
+     * See: https://developers.soundcloud.com/docs/api/reference#token
+     */
+    @Basic(fetch = FetchType.LAZY)
+    @Column(name = "access_token", nullable = true)
+    private String accessToken;
 
 }

--- a/src/test/java/me/moodcat/api/RoomAPITest.java
+++ b/src/test/java/me/moodcat/api/RoomAPITest.java
@@ -1,20 +1,10 @@
 package me.moodcat.api;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
 import me.moodcat.database.controllers.ChatDAO;
 import me.moodcat.database.controllers.RoomDAO;
 import me.moodcat.database.entities.ChatMessage;
 import me.moodcat.database.entities.Room;
 import me.moodcat.mood.Mood;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -22,6 +12,15 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class RoomAPITest {

--- a/src/test/java/me/moodcat/database/bootstrapper/Bootstrapper.java
+++ b/src/test/java/me/moodcat/database/bootstrapper/Bootstrapper.java
@@ -1,10 +1,5 @@
 package me.moodcat.database.bootstrapper;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Collections;
-import java.util.List;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Maps;
 import com.google.inject.Inject;
@@ -15,12 +10,18 @@ import me.moodcat.database.controllers.ArtistDAO;
 import me.moodcat.database.controllers.ChatDAO;
 import me.moodcat.database.controllers.RoomDAO;
 import me.moodcat.database.controllers.SongDAO;
+import me.moodcat.database.controllers.UserDAO;
 import me.moodcat.database.embeddables.VAVector;
 import me.moodcat.database.entities.Artist;
 import me.moodcat.database.entities.ChatMessage;
 import me.moodcat.database.entities.Room;
 import me.moodcat.database.entities.Song;
+import me.moodcat.database.entities.User;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -34,6 +35,7 @@ public class Bootstrapper {
     private final Map<Integer, Artist> persistedArtists;
     private final Map<Integer, Song> persistedSongs;
     private final Map<Integer, Room> persistedRooms;
+    private final Map<Integer, User> persistedUsers;
 
     /**
      * ObjectMapper used for the bootstrapper.
@@ -51,17 +53,22 @@ public class Bootstrapper {
 
     private final ChatDAO chatDAO;
 
+    private final UserDAO userDAO;
+
     @Inject
     public Bootstrapper(final ObjectMapper objectMapper, final ArtistDAO artistDAO,
-                        final RoomDAO roomDAO, final SongDAO songDAO, final ChatDAO chatDAO) {
+                        final RoomDAO roomDAO, final SongDAO songDAO, final ChatDAO chatDAO,
+                        final UserDAO userDAO) {
         this.objectMapper = objectMapper;
         this.artistDAO = artistDAO;
         this.roomDAO = roomDAO;
         this.songDAO = songDAO;
         this.chatDAO = chatDAO;
+        this.userDAO = userDAO;
         this.persistedArtists = Maps.newHashMap();
         this.persistedSongs = Maps.newHashMap();
         this.persistedRooms = Maps.newHashMap();
+        this.persistedUsers = Maps.newHashMap();
     }
 
     /**
@@ -70,9 +77,20 @@ public class Bootstrapper {
     @Data
     private static class BEnvironment {
 
+        private List<BUser> users;
+
         private List<BArtist> artists;
 
         private List<BRoom> rooms;
+    }
+
+    @Data
+    private static class BUser {
+
+        private int id;
+
+        private String username;
+
     }
 
     /**
@@ -124,7 +142,7 @@ public class Bootstrapper {
     @Data
     private static class BMessage {
 
-        private String author;
+        private Integer userId;
 
         private String message;
 
@@ -142,9 +160,20 @@ public class Bootstrapper {
     public void parseFromResource(final String path) throws IOException {
         try (InputStream in = Bootstrapper.class.getResourceAsStream(path)) {
             final BEnvironment environment = objectMapper.readValue(in, BEnvironment.class);
+            environment.getUsers().forEach(this::createUser);
             environment.getArtists().forEach(this::createArtist);
             environment.getRooms().forEach(this::createRoom);
         }
+    }
+
+    @Transactional
+    protected void createUser(BUser bUser) {
+        final User user = new User();
+        user.setId(bUser.getId());
+        user.setName(bUser.getUsername());
+        User persistedUser = userDAO.merge(user);
+        persistedUsers.put(persistedUser.getId(), persistedUser);
+        log.info("Bootstrapper created user {}", persistedUser);
     }
 
     @Transactional
@@ -165,7 +194,7 @@ public class Bootstrapper {
     @Transactional
     protected ChatMessage createChatMessage(BMessage bMessage, Room room) {
         ChatMessage chatMessage = new ChatMessage();
-        chatMessage.setAuthor(bMessage.getAuthor());
+        chatMessage.setUser(persistedUsers.get(bMessage.getUserId()));
         chatMessage.setMessage(bMessage.getMessage());
         chatMessage.setTimestamp(bMessage.getTime());
         chatMessage.setRoom(room);

--- a/src/test/java/me/moodcat/database/entities/ChatMessageTest.java
+++ b/src/test/java/me/moodcat/database/entities/ChatMessageTest.java
@@ -15,7 +15,6 @@ public class ChatMessageTest extends EqualsHashCodeTestCase {
     protected Object createInstance() throws Exception {
         final ChatMessage chatMessage = new ChatMessage();
         chatMessage.setId(3);
-        chatMessage.setAuthor("Henk");
         chatMessage.setMessage("Hello");
         final Room room = new Room();
         room.setName("Stub ROom");
@@ -29,7 +28,6 @@ public class ChatMessageTest extends EqualsHashCodeTestCase {
     protected Object createNotEqualInstance() throws Exception {
         final ChatMessage chatMessage = new ChatMessage();
         chatMessage.setId(4);
-        chatMessage.setAuthor("Henk");
         chatMessage.setMessage("Hello");
         final Room room = new Room();
         room.setName("Stub Room 2");

--- a/src/test/resources/bootstrap/artists.json
+++ b/src/test/resources/bootstrap/artists.json
@@ -1,4 +1,5 @@
 {
+	"users": [],
 	"artists":[
 		{
 			"id": 1,

--- a/src/test/resources/bootstrap/fall-out-boy.json
+++ b/src/test/resources/bootstrap/fall-out-boy.json
@@ -1,4 +1,10 @@
 {
+	"users":[
+		{
+			"id": 1,
+			"username": "System"
+		}
+	],
 	"artists":[
 		{
 			"id": 1,
@@ -23,7 +29,7 @@
 			"songId" : 1,
 			"messages": [
 				{
-					"author": "System",
+					"userId": 1,
 					"message": "Welcome to Moodcat!",
 					"time": 1432799172510
 				}

--- a/src/test/resources/bootstrap/rooms.json
+++ b/src/test/resources/bootstrap/rooms.json
@@ -1,4 +1,10 @@
 {
+	"users":[
+		{
+			"id": 1,
+			"username": "System"
+		}
+	],
 	"artists":[
 		{
 			"id": 1,
@@ -23,7 +29,7 @@
 			"songId" : 1,
 			"messages": [
 				{
-					"author": "System",
+					"userId": 1,
 					"message": "Welcome to Moodcat!",
 					"time": 1432799172510
 				}
@@ -37,7 +43,7 @@
 			"songId" : 1,
 			"messages": [
 				{
-					"author": "System",
+					"userId": 1,
 					"message": "Welcome to Moodcat!",
 					"time": 1432799172510
 				}
@@ -51,7 +57,7 @@
 			"songId" : 1,
 			"messages": [
 				{
-					"author": "System",
+					"userId": 1,
 					"message": "Welcome to Moodcat!",
 					"time": 1432799172510
 				}


### PR DESCRIPTION
This commit adds a user enity and DAO. The user has a username and moodcat Id.
I have also added fields for soundcloud id and soundcloud oauth tokens.
This way we can persist the soundcloud login with a cookie, rather than require a new login on each page refresh.
I've also bounded the author field for chat messages to the user.
We might want to debate on wether or not this is desirable.
Pros: no possible username manipulation for the chat, the username is enforced by the relational model.
Cons: we will have to refactor the frontend and API call in order to merge in this PR (basically you should have a user attached to the session).

For this PR to work in production the database model needs to be updated accordingly.
The test database (h2) however works (and the bootstrapper is updated as well)