### PR TITLE
Fixed room backend

### DIFF
--- a/src/main/java/me/moodcat/api/RoomAPI.java
+++ b/src/main/java/me/moodcat/api/RoomAPI.java
@@ -1,10 +1,19 @@
 package me.moodcat.api;
 
-import algorithms.KNearestNeighbours;
-import com.google.common.annotations.VisibleForTesting;
-import com.google.inject.Inject;
-import com.google.inject.persist.Transactional;
-import datastructures.dataholders.Pair;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
 import me.moodcat.api.models.NowPlaying;
 import me.moodcat.api.models.RoomModel;
 import me.moodcat.api.models.SongModel;
@@ -17,19 +26,13 @@ import me.moodcat.database.entities.Room;
 import me.moodcat.database.entities.Room.RoomDistanceMetric;
 import me.moodcat.database.entities.Song;
 import me.moodcat.mood.Mood;
+import algorithms.KNearestNeighbours;
 
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DefaultValue;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.MediaType;
-import java.util.Collection;
-import java.util.List;
-import java.util.stream.Collectors;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.inject.Inject;
+import com.google.inject.persist.Transactional;
+
+import datastructures.dataholders.Pair;
 
 /**
  * The API for the room.
@@ -98,7 +101,7 @@ public class RoomAPI {
 
     /**
      * Transform a {@link RoomInstance} into a roommodel.
-     * 
+     *
      * @param roomInstance
      *            The instance to create a roommodel from.
      * @return The roommodel that represents the roominstance.
@@ -108,7 +111,7 @@ public class RoomAPI {
         final RoomModel roomModel = new RoomModel();
         final SongModel songModel = SongModel.transform(roomInstance.getCurrentSong());
         final NowPlaying nowPlaying = new NowPlaying(roomInstance.getCurrentTime(), songModel);
-        
+
         roomModel.setId(roomInstance.getId());
         roomModel.setName(roomInstance.getName());
         roomModel.setNowPlaying(nowPlaying);
@@ -163,18 +166,19 @@ public class RoomAPI {
     }
 
     /**
-     * Retrieve whats playing now
+     * Retrieve whats playing now.
+     * 
      * @param roomId
-     *          The id of the room.
+     *            The id of the room.
      * @return
-     *      Whats currently playing in the room
+     *         Whats currently playing in the room
      */
     @GET
     @Path("{id}/now-playing")
     @Transactional
     public NowPlaying getCurrentTime(@PathParam("id") final int roomId) {
-        RoomInstance roomInstance = backend.getRoomInstance(roomId);
-        Song song = roomInstance.getCurrentSong();
+        final RoomInstance roomInstance = backend.getRoomInstance(roomId);
+        final Song song = roomInstance.getCurrentSong();
 
         final NowPlaying nowPlaying = new NowPlaying();
         nowPlaying.setSong(SongModel.transform(song));

--- a/src/main/java/me/moodcat/api/RoomAPI.java
+++ b/src/main/java/me/moodcat/api/RoomAPI.java
@@ -1,19 +1,10 @@
 package me.moodcat.api;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.stream.Collectors;
-
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DefaultValue;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.MediaType;
-
+import algorithms.KNearestNeighbours;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.inject.Inject;
+import com.google.inject.persist.Transactional;
+import datastructures.dataholders.Pair;
 import me.moodcat.api.models.RoomModel;
 import me.moodcat.api.models.SongModel;
 import me.moodcat.backend.RoomBackend;
@@ -24,13 +15,19 @@ import me.moodcat.database.entities.ChatMessage;
 import me.moodcat.database.entities.Room;
 import me.moodcat.database.entities.Room.RoomDistanceMetric;
 import me.moodcat.mood.Mood;
-import algorithms.KNearestNeighbours;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.inject.Inject;
-import com.google.inject.persist.Transactional;
-
-import datastructures.dataholders.Pair;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * The API for the room.
@@ -106,10 +103,10 @@ public class RoomAPI {
      */
     public static RoomModel transform(final RoomBackend.RoomInstance roomInstance) {
         final RoomModel roomModel = new RoomModel();
-        roomModel.setId(roomInstance.getRoom().getId());
+        roomModel.setId(roomInstance.getId());
         roomModel.setName(roomInstance.getName());
         roomModel.setSong(SongModel.transform(roomInstance.getCurrentSong()));
-        roomModel.setTime(roomInstance.getCurrentTime());
+        roomModel.setTime((int) roomInstance.getCurrentTime());
         return roomModel;
     }
 
@@ -159,9 +156,7 @@ public class RoomAPI {
     @Transactional
     public ChatMessage postChatMessage(final ChatMessage msg, @PathParam("id") final int roomId) {
         final RoomBackend.RoomInstance roomInstance = backend.getRoomInstance(roomId);
-        msg.setRoom(roomInstance.getRoom());
         msg.setTimestamp(System.currentTimeMillis() / SECOND_OF_MILISECONDS);
-
         roomInstance.sendMessage(msg);
         return msg;
     }
@@ -169,7 +164,7 @@ public class RoomAPI {
     @GET
     @Path("{id}/time")
     @Transactional
-    public int getCurrentTime(@PathParam("id") final int roomId) {
+    public long getCurrentTime(@PathParam("id") final int roomId) {
         return backend.getRoomInstance(roomId).getCurrentTime();
     }
 

--- a/src/main/java/me/moodcat/api/models/NowPlaying.java
+++ b/src/main/java/me/moodcat/api/models/NowPlaying.java
@@ -1,0 +1,31 @@
+package me.moodcat.api.models;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * The now playing model contains the current song and the time for a room.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class NowPlaying {
+
+    /**
+     * The current time
+     *
+     * @param time the current time
+     * @return the current time
+     */
+    private long time;
+
+    /**
+     * The current song.
+     *
+     * @param song the current song
+     * @return the current song
+     */
+    private SongModel song;
+
+}

--- a/src/main/java/me/moodcat/api/models/NowPlaying.java
+++ b/src/main/java/me/moodcat/api/models/NowPlaying.java
@@ -13,9 +13,10 @@ import lombok.NoArgsConstructor;
 public class NowPlaying {
 
     /**
-     * The current time
+     * The current time.
      *
-     * @param time the current time
+     * @param time
+     *            the current time
      * @return the current time
      */
     private long time;
@@ -23,7 +24,8 @@ public class NowPlaying {
     /**
      * The current song.
      *
-     * @param song the current song
+     * @param song
+     *            the current song
      * @return the current song
      */
     private SongModel song;

--- a/src/main/java/me/moodcat/api/models/RoomModel.java
+++ b/src/main/java/me/moodcat/api/models/RoomModel.java
@@ -16,7 +16,8 @@ public class RoomModel {
     /**
      * The name of the room model.
      *
-     * @param name name for this room
+     * @param name
+     *            name for this room
      * @return name for this room
      */
     private String name;
@@ -24,13 +25,15 @@ public class RoomModel {
     /**
      * The song currently playing in the room.
      *
-     * @param song the song currently playing in the room
+     * @param song
+     *            the song currently playing in the room
      * @return the song currently playing in the room
      */
     private NowPlaying nowPlaying;
 
     /**
-     * The song for the current room
+     * The song for the current room.
+     * 
      * @return the song for this room
      * @deprecated Replaced by the now playing field
      */
@@ -40,7 +43,8 @@ public class RoomModel {
     }
 
     /**
-     * The time in the room
+     * The time in the room.
+     * 
      * @return the song for this room
      * @deprecated Replaced by the now playing field
      */

--- a/src/main/java/me/moodcat/api/models/RoomModel.java
+++ b/src/main/java/me/moodcat/api/models/RoomModel.java
@@ -14,14 +14,6 @@ public class RoomModel {
     private Integer id;
 
     /**
-     * The current song of the room model.
-     *
-     * @param song Song for this room
-     * @return Song for this room
-     */
-    private SongModel song;
-
-    /**
      * The name of the room model.
      *
      * @param name name for this room
@@ -30,11 +22,31 @@ public class RoomModel {
     private String name;
 
     /**
-     * Song time.
+     * The song currently playing in the room.
      *
-     * @param time time for this room
-     * @return time for this room
+     * @param song the song currently playing in the room
+     * @return the song currently playing in the room
      */
-    private Integer time;
+    private NowPlaying nowPlaying;
+
+    /**
+     * The song for the current room
+     * @return the song for this room
+     * @deprecated Replaced by the now playing field
+     */
+    @Deprecated
+    public SongModel getSong() {
+        return nowPlaying.getSong();
+    }
+
+    /**
+     * The time in the room
+     * @return the song for this room
+     * @deprecated Replaced by the now playing field
+     */
+    @Deprecated
+    public Long getTime() {
+        return nowPlaying.getTime();
+    }
 
 }

--- a/src/main/java/me/moodcat/core/App.java
+++ b/src/main/java/me/moodcat/core/App.java
@@ -11,6 +11,7 @@ import com.google.inject.servlet.ServletModule;
 import com.google.inject.util.Modules;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
+import me.moodcat.backend.RoomBackend;
 import me.moodcat.database.DbModule;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.ContextHandlerCollection;
@@ -19,6 +20,7 @@ import org.eclipse.jetty.server.session.HashSessionIdManager;
 import org.eclipse.jetty.server.session.HashSessionManager;
 import org.eclipse.jetty.servlet.FilterHolder;
 import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.util.component.LifeCycle;
 import org.eclipse.jetty.util.resource.Resource;
 import org.jboss.resteasy.plugins.guice.GuiceResteasyBootstrapServletContextListener;
 import org.jboss.resteasy.plugins.guice.ext.JaxrsModule;
@@ -238,7 +240,7 @@ public class App {
      * MoodCat base API service. It tells Google Guice which classes (and their
      * dependencies) to instantiate.
      */
-    public static class MoodcatServletModule extends ServletModule {
+    public class MoodcatServletModule extends ServletModule {
 
         /**
          * The string representation of the api package.
@@ -272,6 +274,8 @@ public class App {
             this.bindDatabaseModule();
             this.bindAPI();
             this.bindExceptionMappers();
+            this.bind(LifeCycle.class).toInstance(server);
+            this.bind(RoomBackend.class).asEagerSingleton();
         }
 
         private void bindDatabaseModule() {

--- a/src/main/java/me/moodcat/database/entities/Room.java
+++ b/src/main/java/me/moodcat/database/entities/Room.java
@@ -62,7 +62,7 @@ public class Room {
     /**
      * Songs to be played.
      */
-    @ManyToMany(fetch = EAGER)
+    @ManyToMany(fetch = EAGER, cascade = ALL)
     @JoinTable(name = "room_play_queue", joinColumns = {
             @JoinColumn(name = "room_id", referencedColumnName = "id")
     }, inverseJoinColumns = {
@@ -79,7 +79,7 @@ public class Room {
     /**
      * The songs recently played in the roomProvider&lt;ChatDAO&gt; chatDAOProvider.
      */
-    @ManyToMany(fetch = LAZY)
+    @ManyToMany(fetch = LAZY, cascade = ALL)
     @JoinTable(name = "room_play_history", joinColumns = {
             @JoinColumn(name = "room_id", referencedColumnName = "id")
     }, inverseJoinColumns = {

--- a/src/test/java/TestPackageAppRunner.java
+++ b/src/test/java/TestPackageAppRunner.java
@@ -1,6 +1,7 @@
+import com.google.inject.Injector;
+import me.moodcat.backend.RoomBackend;
 import me.moodcat.core.App;
 import me.moodcat.database.bootstrapper.Bootstrapper;
-
 import org.slf4j.bridge.SLF4JBridgeHandler;
 
 /**
@@ -18,8 +19,17 @@ public class TestPackageAppRunner {
 
         final App app = new App();
         app.startServer();
-        final Bootstrapper bootstrappper = app.getInjector().getInstance(Bootstrapper.class);
+
+        Injector injector = app.getInjector();
+
+        // Bootstrap the database
+        final Bootstrapper bootstrappper = injector.getInstance(Bootstrapper.class);
         bootstrappper.parseFromResource("/bootstrap/fall-out-boy.json");
+
+        // Init inserted rooms
+        final RoomBackend roomBackend = injector.getInstance(RoomBackend.class);
+        roomBackend.initializeRooms();
+
         app.joinThread();
     }
 }

--- a/src/test/java/me/moodcat/api/RoomAPITest.java
+++ b/src/test/java/me/moodcat/api/RoomAPITest.java
@@ -115,6 +115,5 @@ public class RoomAPITest {
         this.roomAPI.postChatMessage(message, 1);
 
         verify(chatBackend.getRoomInstance(1)).sendMessage(message);
-        assertEquals(oneRoom, message.getRoom());
     }
 }

--- a/src/test/java/me/moodcat/api/RoomAPITest.java
+++ b/src/test/java/me/moodcat/api/RoomAPITest.java
@@ -75,10 +75,10 @@ public class RoomAPITest {
     }
 
     private void mockRoom(Room room, RoomBackend.RoomInstance roomInstance) {
-        when(roomInstance.getRoom()).thenReturn(room);
+//        when(roomInstance.getRoom()).thenReturn(room);
         when(chatBackend.getRoomInstance(room.getId())).thenReturn(roomInstance);
         when(roomInstance.getMessages()).thenReturn(messagesList);
-        when(roomInstance.getRoom()).thenReturn(room);
+//        when(roomInstance.getRoom()).thenReturn(room);
 
     }
 

--- a/src/test/java/me/moodcat/api/models/RoomModelTest.java
+++ b/src/test/java/me/moodcat/api/models/RoomModelTest.java
@@ -11,23 +11,21 @@ public class RoomModelTest extends EqualsHashCodeTestCase {
         super(name);
     }
 
-    private SongModel song = new SongModel();
+    private NowPlaying nowPlaying = new NowPlaying();
 
     @Override
     protected RoomModel createInstance() throws Exception {
         RoomModel model = new RoomModel();
-        model.setTime(0);
-        model.setSong(song);
         model.setName("First room");
+        model.setNowPlaying(nowPlaying);
         return model;
     }
 
     @Override
     protected Object createNotEqualInstance() throws Exception {
         RoomModel model = new RoomModel();
-        model.setTime(0);
-        model.setSong(song);
         model.setName("Second room");
+        model.setNowPlaying(nowPlaying);
         return model;
     }
 }

--- a/src/test/java/me/moodcat/backend/BackendTest.java
+++ b/src/test/java/me/moodcat/backend/BackendTest.java
@@ -1,0 +1,41 @@
+package me.moodcat.backend;
+
+import me.moodcat.database.entities.Artist;
+import me.moodcat.database.entities.ChatMessage;
+import me.moodcat.database.entities.Song;
+
+import java.math.BigInteger;
+import java.util.Random;
+
+/**
+ * Abstract {@code BackendTest} for some shared logic for testing backends.
+ */
+public abstract class BackendTest {
+
+    protected static final Random random = new Random();
+
+    protected static ChatMessage createChatMessage() {
+        final ChatMessage chatMessage = new ChatMessage();
+        chatMessage.setAuthor(randomString());
+        chatMessage.setMessage(randomString());
+        chatMessage.setTimestamp(System.currentTimeMillis());
+        return chatMessage;
+    }
+
+    protected static Song createSong(final int id) {
+        final Song song = new Song();
+        final Artist artist = new Artist();
+        artist.setId(id);
+        artist.setName(randomString());
+        song.setId(id);
+        song.setArtist(artist);
+        song.setName(randomString());
+        song.setArtworkUrl(randomString());
+        song.setDuration((random.nextInt() + 1) * 1000);
+        return song;
+    }
+
+    protected static String randomString() {
+        return new BigInteger(130, random).toString(32);
+    }
+}

--- a/src/test/java/me/moodcat/backend/RoomBackendTest.java
+++ b/src/test/java/me/moodcat/backend/RoomBackendTest.java
@@ -1,17 +1,26 @@
 package me.moodcat.backend;
 
-import com.google.common.collect.Lists;
-import com.google.inject.Provider;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Future;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+
 import me.moodcat.backend.RoomBackend.RoomInstance;
-import me.moodcat.database.controllers.ChatDAO;
 import me.moodcat.database.controllers.RoomDAO;
 import me.moodcat.database.controllers.SongDAO;
-import me.moodcat.database.entities.Artist;
 import me.moodcat.database.entities.ChatMessage;
 import me.moodcat.database.entities.Room;
 import me.moodcat.database.entities.Song;
 import me.moodcat.util.CallableInUnitOfWork;
 import me.moodcat.util.CallableInUnitOfWork.CallableInUnitOfWorkFactory;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -22,21 +31,8 @@ import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import java.math.BigInteger;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Random;
-import java.util.concurrent.Callable;
-import java.util.concurrent.Future;
-import java.util.concurrent.FutureTask;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
-
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.when;
+import com.google.common.collect.Lists;
+import com.google.inject.Provider;
 
 @RunWith(MockitoJUnitRunner.class)
 public class RoomBackendTest extends BackendTest {

--- a/src/test/java/me/moodcat/backend/RoomBackendTest.java
+++ b/src/test/java/me/moodcat/backend/RoomBackendTest.java
@@ -1,18 +1,7 @@
 package me.moodcat.backend;
 
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.when;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.Callable;
-import java.util.concurrent.Future;
-import java.util.concurrent.FutureTask;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
-
+import com.google.common.collect.Lists;
+import com.google.inject.Provider;
 import me.moodcat.backend.RoomBackend.RoomInstance;
 import me.moodcat.database.controllers.ChatDAO;
 import me.moodcat.database.controllers.RoomDAO;
@@ -21,7 +10,6 @@ import me.moodcat.database.entities.Room;
 import me.moodcat.database.entities.Song;
 import me.moodcat.util.CallableInUnitOfWork;
 import me.moodcat.util.CallableInUnitOfWork.CallableInUnitOfWorkFactory;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -32,8 +20,18 @@ import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import com.google.common.collect.Lists;
-import com.google.inject.Provider;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Future;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class RoomBackendTest {
@@ -110,8 +108,8 @@ public class RoomBackendTest {
         when(unitOfWorkFactory.create(Matchers.any())).thenAnswer(invocationOnMock ->
                 invocationOnMock.getArgumentAt(0, Callable.class));
 
-        roomBackend = new RoomBackend(roomDAOProvider, unitOfWorkFactory,
-                new MockedExecutorService(4), chatDAOProvider);
+//        roomBackend = new RoomBackend(roomDAOProvider, unitOfWorkFactory,
+//                new MockedExecutorService(4), chatDAOProvider);
     }
 
     @Test

--- a/src/test/java/me/moodcat/database/bootstrapper/Bootstrapper.java
+++ b/src/test/java/me/moodcat/database/bootstrapper/Bootstrapper.java
@@ -176,7 +176,7 @@ public class Bootstrapper {
         song.setId(bSong.getId());
         song.setName(bSong.getName());
         song.setArtworkUrl(bSong.getArtworkUrl());
-        song.setDuration(600);
+        song.setDuration(bSong.getDuration());
         song.setSoundCloudId(bSong.getSoundCloudId());
         song.setArtist(artist);
         song.setValenceArousal(new VAVector(0,0));

--- a/src/test/resources/bootstrap/artists.json
+++ b/src/test/resources/bootstrap/artists.json
@@ -9,7 +9,7 @@
 					"name": "Thanks for the Memories",
 					"artworkUrl": "https://i1.sndcdn.com/artworks-000057992801-cxjxj7-large.jpg",
 					"soundCloudId": 202330997,
-					"duration": 600
+					"duration": 300000
 				}
 			]
 		},
@@ -22,14 +22,14 @@
 					"name": "Thanks for the Base",
 					"artworkUrl": "https://i1.sndcdn.com/artworks-000057992801-cxjxj7-large.jpg",
 					"soundCloudId": 202330997,
-					"duration": 600
+					"duration": 300000
 				},
 				{
 					"id": 3,
 					"name": "Thanks for the Base Extended",
 					"artworkUrl": "https://i1.sndcdn.com/artworks-000057992801-cxjxj7-large.jpg",
 					"soundCloudId": 202330997,
-					"duration": 600
+					"duration": 300000
 				}
 			]
 		},

--- a/src/test/resources/bootstrap/fall-out-boy.json
+++ b/src/test/resources/bootstrap/fall-out-boy.json
@@ -9,7 +9,7 @@
 					"name": "Thanks for the Memories",
 					"artworkUrl": "https://i1.sndcdn.com/artworks-000057992801-cxjxj7-large.jpg",
 					"soundCloudId": 202330997,
-					"duration": 600
+					"duration": 300000
 				}
 			]
 		}

--- a/src/test/resources/bootstrap/rooms.json
+++ b/src/test/resources/bootstrap/rooms.json
@@ -9,7 +9,7 @@
 					"name": "Thanks for the Memories",
 					"artworkUrl": "https://i1.sndcdn.com/artworks-000057992801-cxjxj7-large.jpg",
 					"soundCloudId": 202330997,
-					"duration": 600
+					"duration": 300000
 				}
 			]
 		}


### PR DESCRIPTION
This is the right way to fix #128 and thus replaces #132.
Changes:
- Entities should not be saved in the instances, because they cannot be interacted with beyond unit of works (and the separate thread is not in a unit of work)
- Introduced a song instance which knows its song id and the current time. It implements an observer pattern to unschedule its own timer and to load the new song on completion.
- Loading rooms in lifecycle listener rather than in constructor prevents Guice initialization errors
- Room init should be retriggered manually after using the bootstrapper

 Work to do:
* Javadoc, checkstyle
* Refactoring, responsibilities can be split up more across files
* API endpoints should be tested, the front end compatibility as well
* I broke the tests.