### PR TITLE
Added points implementation. Closes #129

### DIFF
--- a/src/main/java/me/moodcat/api/SongAPI.java
+++ b/src/main/java/me/moodcat/api/SongAPI.java
@@ -3,17 +3,20 @@ package me.moodcat.api;
 import java.util.Arrays;
 import java.util.List;
 
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import me.moodcat.database.controllers.SongDAO;
+import me.moodcat.database.controllers.UserDAO;
 import me.moodcat.database.embeddables.VAVector;
 import me.moodcat.database.entities.Song;
 
@@ -52,14 +55,25 @@ public class SongAPI {
     };
 
     /**
-     * Manager to talk to the database to obtain songs.
+     * The points a user gains when he classifies a song.
+     */
+    private static final int CLASSIFICATION_POINTS_AWARD = 6;
+
+    /**
+     * Java facade to talk to the database to obtain songs.
      */
     private final SongDAO songDAO;
 
+    /**
+     * Java facade to talk to the database for user communication.
+     */
+    private final UserDAO userDAO;
+
     @Inject
     @VisibleForTesting
-    public SongAPI(final SongDAO songDAO) {
+    public SongAPI(final SongDAO songDAO, final UserDAO userDAO) {
         this.songDAO = songDAO;
+        this.userDAO = userDAO;
     }
 
     @GET
@@ -97,7 +111,8 @@ public class SongAPI {
     @Path("{id}/classify")
     @Transactional
     public ClassificationRequest classifySong(@PathParam("id") final int id,
-            final ClassificationRequest classification) throws InvalidClassificationException {
+            final ClassificationRequest classification)
+            throws InvalidClassificationException {
         final Song song = this.songDAO.findBySoundCloudId(id);
         assertDimensionIsValid(classification.getValence());
         assertDimensionIsValid(classification.getArousal());
@@ -106,6 +121,36 @@ public class SongAPI {
             song.setValenceArousal(adjustSongVector(classification, song));
             this.songDAO.merge(song);
         }
+
+        return classification;
+    }
+
+    /**
+     * Process a user classification game for the given songId.
+     *
+     * @param id
+     *            The id of the song.
+     * @param classification
+     *            The classification of the user for the song.
+     * @return The classification provided.
+     * @throws InvalidClassificationException
+     *             When the classification provided was invalid
+     */
+    @POST
+    @Path("{id}/classifygame")
+    @Transactional
+    public ClassificationRequest approachSong(@PathParam("id") final int id,
+            final ClassificationRequest classification,
+            @QueryParam("userid") @DefaultValue("0") final int userId)
+            throws InvalidClassificationException {
+        final Song song = this.songDAO.findBySoundCloudId(id);
+        assertDimensionIsValid(classification.getValence());
+        assertDimensionIsValid(classification.getArousal());
+
+        song.setValenceArousal(new VAVector(classification.getValence(), classification
+                .getArousal()));
+        this.songDAO.merge(song);
+        this.userDAO.incrementPoints(userId, CLASSIFICATION_POINTS_AWARD);
 
         return classification;
     }

--- a/src/main/java/me/moodcat/api/UserAPI.java
+++ b/src/main/java/me/moodcat/api/UserAPI.java
@@ -1,0 +1,103 @@
+package me.moodcat.api;
+
+import java.util.List;
+
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+import me.moodcat.database.controllers.UserDAO;
+import me.moodcat.database.entities.User;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.inject.Inject;
+import com.google.inject.persist.Transactional;
+
+/**
+ * The API for the room.
+ */
+@Path("/api/users/")
+@Produces(MediaType.APPLICATION_JSON)
+public class UserAPI {
+
+    /**
+     * Access to the user DAO.
+     */
+    private final UserDAO userDAO;
+
+    @Inject
+    @VisibleForTesting
+    public UserAPI(final UserDAO userDAO) {
+        this.userDAO = userDAO;
+    }
+
+    @GET
+    @Transactional
+    public List<User> getUsers() {
+        return userDAO.getAll();
+    }
+
+    /**
+     * Get the user according to the provided id.
+     *
+     * @param id
+     *            The id of the user to find.
+     * @return The user according to the id.
+     * @throws IllegalArgumentException
+     *             If the id is null.
+     */
+    @GET
+    @Path("{id}")
+    @Transactional
+    public User getUser(@PathParam("id") final int userId) {
+        return userDAO.retrieveBySoundcloudId(userId);
+    }
+
+    /**
+     * Returns the current user
+     * 
+     * @return
+     */
+    @GET
+    @Path("me")
+    @Transactional
+    public User getMe() {
+        // FIXME: Hardcoded until Oauth works
+        return userDAO.retrieveBySoundcloudId(1);
+    }
+
+    /**
+     * The amount of points a user with id {id} has.
+     * 
+     * @param userId
+     *            The user id we need the points for.
+     * @return The amount of points the user has.
+     */
+    @GET
+    @Path("{id}/points")
+    @Transactional
+    public Integer getPoints(@PathParam("id") final int userId) {
+        return userDAO.retrievePointsBySoundcloudId(userId);
+    }
+
+    /**
+     * The amount of points a user with id userId has earned.
+     * 
+     * @param userId
+     *            The user to update.
+     * @param amount
+     *            The amount of points to be awarded.
+     */
+    @POST
+    @Path("{id}/points")
+    @Transactional
+    public void addPoints(@PathParam("id") final int userId,
+            @QueryParam("amount") @DefaultValue("0") final int amount) {
+        userDAO.incrementPoints(userId, amount);
+    }
+}

--- a/src/main/java/me/moodcat/database/controllers/UserDAO.java
+++ b/src/main/java/me/moodcat/database/controllers/UserDAO.java
@@ -1,11 +1,13 @@
 package me.moodcat.database.controllers;
 
-import me.moodcat.database.entities.User;
+import static me.moodcat.database.entities.QUser.user;
+
+import java.util.List;
 
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
 
-import static me.moodcat.database.entities.QUser.user;
+import me.moodcat.database.entities.User;
 
 /**
  * Data access object for user entities.
@@ -34,6 +36,42 @@ public class UserDAO extends AbstractDAO<User> {
         return ensureExists(query().from(user)
                 .where(user.soundCloudUserId.eq(soundCloudId))
                 .singleResult(user));
+    }
+
+    /**
+     * Returns the amount of points the user has collected.
+     * 
+     * @param soundCloudId
+     *            The Id of the user we're searching for.
+     * @return The amount of points this user has.
+     */
+    public Integer retrievePointsBySoundcloudId(final Integer soundCloudId) {
+        return ensureExists(query().from(user)
+                .where(user.soundCloudUserId.eq(soundCloudId))
+                .singleResult(user)).getPoints();
+    }
+
+    /**
+     * Retrieve all users.
+     * 
+     * @return A list of all users.
+     */
+    public List<User> getAll() {
+        return this.query().from(user).list(user);
+    }
+
+    /**
+     * Updates the user with the id userId with the set amount.
+     * 
+     * @param userId
+     *            The user to update.
+     * @param amount
+     *            The amount of points to award the user.
+     */
+    public void incrementPoints(int userId, int amount) {
+        User usr = this.retrieveBySoundcloudId(userId);
+        usr.increment(amount);
+        this.merge(usr);
     }
 
 }

--- a/src/main/java/me/moodcat/database/entities/User.java
+++ b/src/main/java/me/moodcat/database/entities/User.java
@@ -56,11 +56,29 @@ public class User {
     private String name;
 
     /**
+     * The amount of points the user has collected.
+     * 
+     * @return The amount of points the user has
+     */
+    @Column(name = "points")
+    private int points;
+
+    /**
      * SoundCloud OAuth access token.
      * See: https://developers.soundcloud.com/docs/api/reference#token
      */
     @Basic(fetch = FetchType.LAZY)
     @Column(name = "access_token", nullable = true)
     private String accessToken;
+
+    /**
+     * Updates the points for the user.
+     * 
+     * @param addition
+     *            The amount of points the user gained
+     */
+    public void increment(Integer addition) {
+        this.points = this.getPoints() + addition;
+    }
 
 }

--- a/src/test/java/me/moodcat/database/bootstrapper/Bootstrapper.java
+++ b/src/test/java/me/moodcat/database/bootstrapper/Bootstrapper.java
@@ -33,8 +33,11 @@ import java.util.Map;
 public class Bootstrapper {
 
     private final Map<Integer, Artist> persistedArtists;
+
     private final Map<Integer, Song> persistedSongs;
+
     private final Map<Integer, Room> persistedRooms;
+
     private final Map<Integer, User> persistedUsers;
 
     /**
@@ -57,8 +60,8 @@ public class Bootstrapper {
 
     @Inject
     public Bootstrapper(final ObjectMapper objectMapper, final ArtistDAO artistDAO,
-                        final RoomDAO roomDAO, final SongDAO songDAO, final ChatDAO chatDAO,
-                        final UserDAO userDAO) {
+            final RoomDAO roomDAO, final SongDAO songDAO, final ChatDAO chatDAO,
+            final UserDAO userDAO) {
         this.objectMapper = objectMapper;
         this.artistDAO = artistDAO;
         this.roomDAO = roomDAO;
@@ -90,6 +93,10 @@ public class Bootstrapper {
         private int id;
 
         private String username;
+
+        private int soundCloudUserId;
+
+        private Integer points;
 
     }
 
@@ -171,6 +178,8 @@ public class Bootstrapper {
         final User user = new User();
         user.setId(bUser.getId());
         user.setName(bUser.getUsername());
+        user.setSoundCloudUserId(bUser.getSoundCloudUserId());
+        user.setPoints(bUser.getPoints());
         User persistedUser = userDAO.merge(user);
         persistedUsers.put(persistedUser.getId(), persistedUser);
         log.info("Bootstrapper created user {}", persistedUser);
@@ -209,7 +218,7 @@ public class Bootstrapper {
         song.setDuration(bSong.getDuration());
         song.setSoundCloudId(bSong.getSoundCloudId());
         song.setArtist(artist);
-        song.setValenceArousal(new VAVector(0,0));
+        song.setValenceArousal(new VAVector(0, 0));
         song = songDAO.merge(song);
         persistedSongs.put(bSong.getId(), song);
         return song;
@@ -237,7 +246,9 @@ public class Bootstrapper {
 
     /**
      * Get a persisted artist
-     * @param id id for the artist
+     * 
+     * @param id
+     *            id for the artist
      * @return artist
      */
     public Artist getArtist(Integer id) {
@@ -246,7 +257,9 @@ public class Bootstrapper {
 
     /**
      * Get a persisted Room
-     * @param id id for the Room
+     * 
+     * @param id
+     *            id for the Room
      * @return Room
      */
     public Room getRoom(Integer id) {
@@ -256,7 +269,8 @@ public class Bootstrapper {
     /**
      * Get an artist
      *
-     * @param id id for the Song
+     * @param id
+     *            id for the Song
      * @return an artist
      */
     public Song getSong(Integer id) {

--- a/src/test/resources/bootstrap/fall-out-boy.json
+++ b/src/test/resources/bootstrap/fall-out-boy.json
@@ -2,7 +2,8 @@
 	"users":[
 		{
 			"id": 1,
-			"username": "System"
+			"username": "System",
+			"points": 10
 		}
 	],
 	"artists":[

--- a/src/test/resources/bootstrap/rooms.json
+++ b/src/test/resources/bootstrap/rooms.json
@@ -2,7 +2,8 @@
 	"users":[
 		{
 			"id": 1,
-			"username": "System"
+			"username": "System",
+			"points": 10
 		}
 	],
 	"artists":[


### PR DESCRIPTION
classifygame has somewhat duplication with classify in SongAPI, but it's not really possible to deduplicate.
Frontend can use /api/users/me to retrieve the current user (currently mocked).
If frontend uses the classifygame endpoint the user gains 6 points per rating.