### PR TITLE
Use new transaction on failure

### DIFF
--- a/src/dev/java/me/moodcat/database/bulkInsert/BulkInsertData.java
+++ b/src/dev/java/me/moodcat/database/bulkInsert/BulkInsertData.java
@@ -111,7 +111,6 @@ public class BulkInsertData {
      * @throws SoundCloudException
      *             when the SoundCloud API was not called successfully.
      */
-    @Transactional
     public void insertData() throws IOException, SoundCloudException {
         final SongDAO songDAO = songDAOProvider.get();
         final Map<String, Artist> artistMap = new HashMap<>();
@@ -137,6 +136,7 @@ public class BulkInsertData {
      * @param artistMap
      *            the map with already persisted arists.
      */
+    @Transactional
     private Artist getOrPersistArtist(final String username, final Map<String, Artist> artistMap) {
         final ArtistDAO artistDAO = artistDAOProvider.get();
         Artist artist;


### PR DESCRIPTION
When the bulk insert encounters a failure on persisting a song or artist, it tries to reuse a closed database connection / transaction. Subsequent persists will then fail. Therefore the `@Transactional` annotation should be on the `getOrPersistArtist()` method rather than the `insertData()` method. This PR fixes that problem.


```
Jun 16, 2015 9:26:13 PM com.mchange.v2.c3p0.impl.NewPooledConnection handleThrowable
WARNING: [c3p0] A PooledConnection that has already signalled a Connection error is still in use!
Jun 16, 2015 9:26:13 PM com.mchange.v2.c3p0.impl.NewPooledConnection handleThrowable
```