### PR TITLE
Implemented endpoint to retrieve messages after a given chatmessageId. Fixes #131

### DIFF
--- a/src/main/java/me/moodcat/api/RoomAPI.java
+++ b/src/main/java/me/moodcat/api/RoomAPI.java
@@ -137,6 +137,25 @@ public class RoomAPI {
     }
 
     /**
+     * Get all the message of the room that happened later than where posted after the chatmessage
+     * with the corresponding messageId.
+     * 
+     * @param roomId
+     *            The room the messages were placed in.
+     * @param chatMessageId
+     *            The message id we want to obtain later messages of.
+     * @return A list of messages that happened later than the provided chatMessageId. Can be empty.
+     */
+    @GET
+    @Path("{id}/messages/{chatMessageId}")
+    public List<ChatMessageModel> getMessages(@PathParam("id") final int roomId,
+            @PathParam("chatMessageId") final int chatMessageId) {
+        return backend.getRoomInstance(roomId).getMessages().stream()
+                .filter((message) -> message.getId() > chatMessageId)
+                .collect(Collectors.toList());
+    }
+
+    /**
      * Post a message to a room.
      *
      * @param msg
@@ -191,7 +210,7 @@ public class RoomAPI {
         final RoomInstance roomInstance = this.backend.getRoomInstance(roomId);
 
         Vote voteValue = Vote.valueOf(vote.toUpperCase());
-            
+
         roomInstance.addVote(currentUserProvider.get(), voteValue);
 
         return transform(roomInstance);

--- a/src/main/java/me/moodcat/api/RoomAPI.java
+++ b/src/main/java/me/moodcat/api/RoomAPI.java
@@ -199,8 +199,6 @@ public class RoomAPI {
      * @param vote
      *            The vote.
      * @return The song object, if the process was succesful.
-     * @throws InvalidVoteException
-     *             Thrown if an invalid vote was cast.
      */
     @POST
     @Path("{id}/vote/{vote}")


### PR DESCRIPTION
Chat polling which simply checks for all messages the id and returns the list.