### PR TITLE
Fix room history duplication

### DIFF
--- a/src/main/java/me/moodcat/backend/rooms/RoomInstance.java
+++ b/src/main/java/me/moodcat/backend/rooms/RoomInstance.java
@@ -207,6 +207,7 @@ public class RoomInstance {
         final List<Song> playQueue = room.getPlayQueue();
         if (playQueue.isEmpty()) {
             playQueue.addAll(history);
+            history.clear();
         }
 
         playNext(playQueue.remove(0));

--- a/src/test/java/me/moodcat/backend/rooms/RoomBackendTest.java
+++ b/src/test/java/me/moodcat/backend/rooms/RoomBackendTest.java
@@ -1,6 +1,7 @@
 package me.moodcat.backend.rooms;
 
 import static org.hamcrest.Matchers.contains;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
@@ -187,6 +188,9 @@ public class RoomBackendTest extends BackendTest {
     @Test
     public void playSongCreatesQueueWhenRepeating() {
         when(room.getPlayQueue()).thenReturn(Lists.newArrayList());
+
+        Song mockedSong = mock(Song.class);
+        when(room.getPlayHistory()).thenReturn(Lists.newArrayList(mockedSong));
         room.setRepeat(true);
 
         final RoomInstance instance = roomBackend.getRoomInstance(1);
@@ -194,30 +198,46 @@ public class RoomBackendTest extends BackendTest {
         instance.playNext();
         instance.merge();
 
-        assertNotEquals(room.getPlayHistory(), room.getPlayQueue());
+        assertFalse(room.getPlayQueue().isEmpty());
     }
-    
+
+    @Test
+    public void playSongRemovesHistoryWhenRepeating() {
+        when(room.getPlayQueue()).thenReturn(Lists.newArrayList());
+
+        Song mockedSong = mock(Song.class);
+        when(room.getPlayHistory()).thenReturn(Lists.newArrayList(mockedSong));
+        room.setRepeat(true);
+
+        final RoomInstance instance = roomBackend.getRoomInstance(1);
+
+        instance.playNext();
+        instance.merge();
+
+        assertTrue(room.getPlayHistory().isEmpty());
+    }
+
     @Test
     public void playSongProcessVotesAndAddsRoomToExclusionWhenTooManyDislikes() {
         Song mockedSong = mock(Song.class);
         when(room.getCurrentSong()).thenReturn(mockedSong);
-        
+
         final RoomInstance instance = roomBackend.getRoomInstance(1);
         instance.addVote(user, Vote.DISLIKE);
         instance.playNext();
-        
+
         verify(mockedSong).addExclusionRoom(room);
     }
-    
+
     @Test
     public void playSongProcessVotesDoesNotAddRoomToExclusionWhenNotEngouhDislikes() {
         Song mockedSong = Mockito.mock(Song.class);
         when(room.getCurrentSong()).thenReturn(mockedSong);
-        
+
         final RoomInstance instance = roomBackend.getRoomInstance(1);
         instance.addVote(user, Vote.LIKE);
         instance.playNext();
-        
+
         verify(mockedSong, never()).addExclusionRoom(room);
     }
 


### PR DESCRIPTION
When the room queue is empty and the repeat flag is true, the entire history of the room is added to the play queue, once the room is through this queue and all those songs are added to the history again the process repeats, this fixes this.