### PR TITLE
E2e refactor

### DIFF
--- a/src/main/java/me/moodcat/api/models/ExceptionResponse.java
+++ b/src/main/java/me/moodcat/api/models/ExceptionResponse.java
@@ -1,0 +1,33 @@
+package me.moodcat.api.models;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * The response to the frontend.
+ */
+public class ExceptionResponse {
+
+    /**
+     * The unique id for the exception.
+     *
+     * @param uuid
+     *            The new unique id of this response.
+     * @return The unique id of this response.
+     */
+    @Getter
+    @Setter
+    private String uuid;
+
+    /**
+     * The exception message.
+     *
+     * @param message
+     *            The message to inform the user.
+     * @return The message of this response.
+     */
+    @Getter
+    @Setter
+    private String message;
+
+}

--- a/src/main/java/me/moodcat/core/mappers/AbstractExceptionMapper.java
+++ b/src/main/java/me/moodcat/core/mappers/AbstractExceptionMapper.java
@@ -7,9 +7,8 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.ext.ExceptionMapper;
 
-import lombok.Getter;
-import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
+import me.moodcat.api.models.ExceptionResponse;
 
 /**
  * An ExceptionMapper which can catch exceptions and report to the frontend.
@@ -44,34 +43,5 @@ public abstract class AbstractExceptionMapper<T extends Throwable> implements Ex
     }
 
     public abstract Status getStatusCode();
-
-    /**
-     * The response to the frontend.
-     */
-    public static class ExceptionResponse {
-
-        /**
-         * The unique id for the exception.
-         *
-         * @param uuid
-         *            The new unique id of this response.
-         * @return The unique id of this response.
-         */
-        @Getter
-        @Setter
-        private String uuid;
-
-        /**
-         * The exception message.
-         *
-         * @param message
-         *            The message to inform the user.
-         * @return The message of this response.
-         */
-        @Getter
-        @Setter
-        private String message;
-
-    }
 
 }

--- a/src/main/java/me/moodcat/soundcloud/SoundCloudAPIConnector.java
+++ b/src/main/java/me/moodcat/soundcloud/SoundCloudAPIConnector.java
@@ -3,6 +3,8 @@ package me.moodcat.soundcloud;
 import javax.ws.rs.client.Client;
 
 import lombok.SneakyThrows;
+import me.moodcat.util.Invocation;
+
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 
 import java.net.URLEncoder;

--- a/src/main/java/me/moodcat/util/Invocation.java
+++ b/src/main/java/me/moodcat/util/Invocation.java
@@ -1,18 +1,18 @@
-package me.moodcat.soundcloud;
+package me.moodcat.util;
 
 import javax.ws.rs.client.WebTarget;
 
 /**
- * An invocation to the Soundcloud API.
+ * An invocation to a HTTPClient
  *
  * @param <T>
  *            return type
  */
 @FunctionalInterface
-interface Invocation<T> {
+public interface Invocation<T> {
 
     /**
-     * Perform the call to the SoundCloud API.
+     * Perform the call to the HttpClient.
      *
      * @param webTarget
      *            target to interact with
@@ -21,4 +21,5 @@ interface Invocation<T> {
      *             any exception that occurs
      */
     T perform(WebTarget webTarget) throws Exception;
+
 }

--- a/src/test/java/endtoend/ApiEndToEndTest.java
+++ b/src/test/java/endtoend/ApiEndToEndTest.java
@@ -8,31 +8,47 @@ import javax.ws.rs.core.GenericType;
 
 import me.moodcat.api.models.RoomModel;
 import me.moodcat.api.models.SongModel;
+import me.moodcat.database.controllers.SongDAO;
+import me.moodcat.database.entities.Song;
 
 import org.junit.Test;
 
+import com.google.inject.Inject;
+
 public class ApiEndToEndTest extends EndToEndTest {
+
+    @Inject
+    private SongDAO songDAO;
 
     @Test
     public void canRetrieveRoom() {
-        RoomModel room = this.performGETRequest(RoomModel.class, "rooms/1");
-        
+        RoomModel room = this.perform(invocation -> invocation.path("rooms").path("1")
+                .request()
+                .get(RoomModel.class));
+
         assertEquals(1, room.getId().intValue());
         assertEquals(1, room.getNowPlaying().getSong().getId().intValue());
     }
-    
+
     @Test
     public void canRetrieveSongs() {
-        SongModel song = this.performGETRequest(SongModel.class, "songs/1");
-        
-        assertEquals(1, song.getId().intValue());
-        assertEquals(202330997, song.getSoundCloudId().intValue());
+        Song expected = songDAO.findById(1);
+
+        SongModel songModel = this.perform(invocation -> invocation.path("songs").path("1")
+                .request()
+                .get(SongModel.class));
+
+        assertEquals(1, songModel.getId().intValue());
+        assertEquals(expected.getSoundCloudId(), songModel.getSoundCloudId());
     }
-    
+
     @Test
     public void canRetrieveRooms() {
-        List<RoomModel> rooms = this.performGETRequestWithGenericType(new GenericType<List<RoomModel>>(){}, "rooms");
-        
+        List<RoomModel> rooms = this.perform(invocation -> invocation.path("rooms")
+                .request()
+                .get(new GenericType<List<RoomModel>>() {
+                }));
+
         assertEquals(1, rooms.get(0).getId().intValue());
     }
 

--- a/src/test/java/endtoend/ChatMessagesEndToEndTest.java
+++ b/src/test/java/endtoend/ChatMessagesEndToEndTest.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.util.List;
-import java.util.Map;
 
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.GenericType;
@@ -14,8 +13,6 @@ import me.moodcat.api.models.ChatMessageModel;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Test;
-
-import com.google.common.collect.Maps;
 
 public class ChatMessagesEndToEndTest extends EndToEndTest {
 
@@ -44,20 +41,27 @@ public class ChatMessagesEndToEndTest extends EndToEndTest {
 
         ChatMessageModel message2 = postMessage("System", "Second message");
 
-        List<ChatMessageModel> messages = this.performGETRequestWithGenericType(new GenericType<List<ChatMessageModel>>(){}, "rooms/1/messages");
-        
+        List<ChatMessageModel> messages = this.perform(invocation -> invocation.path("rooms")
+                .path("1").path("messages")
+                .request()
+                .get(new GenericType<List<ChatMessageModel>>() {
+                }));
+
         Assert.assertThat(messages, Matchers.hasItems(message1, message2));
     }
-    
+
     @Test
     public void canRetrieveMessagesAfterCertainMessage() {
         ChatMessageModel message1 = postMessage("System", "Second-last message");
 
         ChatMessageModel message2 = postMessage("System", "Last message");
 
-        List<ChatMessageModel> messages = this.performGETRequestWithGenericType(new GenericType<List<ChatMessageModel>>(){},
-                "rooms/1/messages/" + message1.getId());
-        
+        List<ChatMessageModel> messages = this.perform(invocation -> invocation.path("rooms")
+                .path("1").path("messages").path(message1.getId().toString())
+                .request()
+                .get(new GenericType<List<ChatMessageModel>>() {
+                }));
+
         Assert.assertThat(messages, Matchers.contains(message2));
     }
 
@@ -66,13 +70,12 @@ public class ChatMessagesEndToEndTest extends EndToEndTest {
         postMessage.setAuthor(author);
         postMessage.setMessage(contents);
 
-        Map<String, Object> queryParams = Maps.newHashMap();
-        queryParams.put("token", "asdf");
+        ChatMessageModel message = this.perform(invocation -> invocation.path("rooms")
+                .path("1").path("messages")
+                .queryParam("token", "asdf")
+                .request()
+                .post(Entity.json(postMessage), ChatMessageModel.class));
 
-        ChatMessageModel message = this.performPOSTRequestWithQueryParams(ChatMessageModel.class,
-                "rooms/1/messages",
-                Entity.json(postMessage), queryParams);
-        
         return message;
     }
 

--- a/src/test/java/endtoend/EndToEndTest.java
+++ b/src/test/java/endtoend/EndToEndTest.java
@@ -3,25 +3,21 @@ package endtoend;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.function.Function;
-
 import javax.ws.rs.client.Client;
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.client.Invocation.Builder;
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.GenericType;
 
+import lombok.SneakyThrows;
 import me.moodcat.backend.rooms.RoomBackend;
 import me.moodcat.core.App;
 import me.moodcat.database.bootstrapper.Bootstrapper;
 import me.moodcat.soundcloud.SoundCloudIdentifier;
 import me.moodcat.soundcloud.models.MeModel;
+import me.moodcat.util.InjectTestRule;
+import me.moodcat.util.Invocation;
 
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.mockito.Matchers;
 
 import com.google.inject.AbstractModule;
@@ -29,9 +25,14 @@ import com.google.inject.Injector;
 
 public abstract class EndToEndTest {
 
+    private static final String LOCAL_API_ENDPOINT = "http://localhost:8080/api";
+
     private static App app;
 
     private static SoundCloudIdentifier soundCloudIdentifier = mock(SoundCloudIdentifier.class);
+
+    @Rule
+    public InjectTestRule injectTestRule = new InjectTestRule(app.getInjector());
 
     @BeforeClass
     public static void setUpClass() throws Exception {
@@ -79,70 +80,18 @@ public abstract class EndToEndTest {
      * @return The HTTP-client.
      */
     protected Client createClient() {
-        return ResteasyClientBuilder.newBuilder().build();
+        return ResteasyClientBuilder.newBuilder()
+                .build();
     }
 
-    protected <T> T performGETRequest(final Class<T> clazz, final String endPoint) {
-        return this.performRequest(endPoint, (response) -> response.get(clazz));
+    @SneakyThrows
+    protected <T> T perform(final Invocation<T> invocation) {
+        Client client = createClient();
+        try {
+            return invocation.perform(client.target(LOCAL_API_ENDPOINT));
+        } finally {
+            client.close();
+        }
     }
 
-    protected <T> T performGETRequestWithQueryParameters(final Class<T> clazz,
-            final String endPoint,
-            Map<String, Object> queryParameters) {
-        return this.performRequestWithQueryParams(clazz, endPoint,
-                (response) -> response.get(clazz), queryParameters);
-    }
-
-    protected <T> T performGETRequestWithGenericType(final GenericType<T> genericType,
-            final String endPoint) {
-        return this.performRequest(endPoint, (response) -> response.get(genericType));
-    }
-
-    protected <T> T performPOSTRequest(final Class<T> clazz,
-            final String endPoint, final Entity<?> postEntity) {
-        return this.performRequest(endPoint, (response) -> response.post(postEntity, clazz));
-    }
-
-    protected <T> T performPOSTRequestWithQueryParams(Class<T> clazz,
-            String endPoint, Entity<T> postEntity, Map<String, Object> queryParameters) {
-        return this.performRequestWithQueryParams(clazz, endPoint,
-                (response) -> response.post(postEntity, clazz), queryParameters);
-    }
-
-    protected <T> T performRequestWithQueryParams(final Class<T> clazz,
-            final String endPoint, final Function<Builder, T> callFunction,
-            final Map<String, Object> queryParameters) {
-        return this.performRequest(
-                endPoint,
-                callFunction,
-                (target) -> {
-                    WebTarget targetWithParams = target;
-
-                    for (Entry<String, Object> entry : queryParameters.entrySet()) {
-                        targetWithParams = targetWithParams.queryParam(entry.getKey(),
-                                entry.getValue());
-                    }
-
-                    return targetWithParams;
-                });
-    }
-
-    private <T> T performRequest(final String endPoint, final Function<Builder, T> callFunction) {
-        return this.performRequest(endPoint, callFunction, (target) -> target);
-    }
-
-    private <T> T performRequest(final String endPoint, final Function<Builder, T> callFunction,
-            final Function<WebTarget, WebTarget> applyQueryParams) {
-        Client client = this.createClient();
-
-        WebTarget target = client.target("http://localhost:8080/api");
-
-        target = applyQueryParams.apply(target);
-
-        Builder response = target.path(endPoint).request("application/json");
-
-        T entity = callFunction.apply(response);
-        client.close();
-        return entity;
-    }
 }

--- a/src/test/java/endtoend/ExceptionHandlingEndToEndTest.java
+++ b/src/test/java/endtoend/ExceptionHandlingEndToEndTest.java
@@ -1,26 +1,32 @@
 package endtoend;
 
-import javax.ws.rs.NotFoundException;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import static org.junit.Assert.assertEquals;
 
+import javax.ws.rs.core.Response;
+
+import me.moodcat.api.models.ExceptionResponse;
+
+import org.junit.Test;
 
 public class ExceptionHandlingEndToEndTest extends EndToEndTest {
-    
-    @Rule
-    public ExpectedException expected = ExpectedException.none();
-    
+
     @Test
     public void error404IsCorrectlyHandled() {
-        expected.expect(NotFoundException.class);
-        this.performGETRequest(Object.class, "bogus");
+        Response response = this.perform(invocation -> invocation.path("bogus").request().get());
+        ExceptionResponse exceptionResponse = response.readEntity(ExceptionResponse.class);
+        assertEquals("Could not find resource for full path: http://localhost:8080/api/bogus",
+                exceptionResponse.getMessage());
+        assertEquals(404, response.getStatus());
     }
-    
+
     @Test
     public void error403IsCorrectlyHandled() {
-        expected.expectMessage("HTTP 403 Forbidden");
-        this.performGETRequest(Object.class, "users/me");
+        Response response = this.perform(invocation -> invocation.path("users").path("me")
+                .request()
+                .get());
+        ExceptionResponse exceptionResponse = response.readEntity(ExceptionResponse.class);
+        assertEquals("HTTP 401 Unauthorized", exceptionResponse.getMessage());
+        assertEquals(403, response.getStatus());
     }
 
 }

--- a/src/test/java/endtoend/PointsEndToEndTest.java
+++ b/src/test/java/endtoend/PointsEndToEndTest.java
@@ -2,34 +2,38 @@ package endtoend;
 
 import static org.junit.Assert.assertTrue;
 
-import java.util.Map;
-
 import javax.ws.rs.client.Entity;
 
 import me.moodcat.api.SongAPI.ClassificationRequest;
-import org.junit.Test;
 
-import com.google.common.collect.Maps;
+import org.junit.Test;
 
 public class PointsEndToEndTest extends EndToEndTest {
 
     @Test
     public void canObtainPointsWhenClassifying() {
-        Map<String, Object> queryParams = Maps.newHashMap();
-        queryParams.put("token", "asdf");
-        
-        Integer oldPoints = this.performGETRequestWithQueryParameters(Integer.class, "users/me/points", queryParams);
-        
+        Integer oldPoints = fetchPoints();
+
         ClassificationRequest request = new ClassificationRequest();
         request.setArousal(0.5);
         request.setValence(-0.5);
 
-        this.performPOSTRequestWithQueryParams(ClassificationRequest.class,
-                "songs/202330997/classify",
-                Entity.json(request), queryParams);
-        
-        Integer newPoints = this.performGETRequestWithQueryParameters(Integer.class, "users/me/points", queryParams);
+        this.perform(invocation -> invocation.path("songs")
+                .path("202330997").path("classify")
+                .queryParam("token", "asdf")
+                .request()
+                .post(Entity.json(request)));
+
+        Integer newPoints = fetchPoints();
         assertTrue(oldPoints < newPoints);
+    }
+
+    private Integer fetchPoints() {
+        return this.perform(invocation -> invocation.path("users").path("me")
+                .path("points")
+                .queryParam("token", "asdf")
+                .request()
+                .get(Integer.class));
     }
 
 }

--- a/src/test/java/me/moodcat/core/mappers/ExceptionMapperTest.java
+++ b/src/test/java/me/moodcat/core/mappers/ExceptionMapperTest.java
@@ -4,6 +4,8 @@ import static org.junit.Assert.assertEquals;
 
 import javax.ws.rs.core.Response;
 
+import me.moodcat.api.models.ExceptionResponse;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -32,7 +34,7 @@ public abstract class ExceptionMapperTest<T extends Throwable> {
     @Test
     public void testToResponse() throws Exception {
         final Response response = mapper.toResponse(exception);
-        final AbstractExceptionMapper.ExceptionResponse responseEntity = (AbstractExceptionMapper.ExceptionResponse) response
+        final ExceptionResponse responseEntity = (ExceptionResponse) response
                 .getEntity();
         assertEquals(responseEntity.getMessage(), exception.getMessage());
     }
@@ -42,7 +44,7 @@ public abstract class ExceptionMapperTest<T extends Throwable> {
         final String message = "Test Message";
         Mockito.when(exception.getMessage()).thenReturn(message);
         final Response response = mapper.toResponse(exception);
-        final AbstractExceptionMapper.ExceptionResponse responseEntity = (AbstractExceptionMapper.ExceptionResponse) response
+        final ExceptionResponse responseEntity = (ExceptionResponse) response
                 .getEntity();
         assertEquals(responseEntity.getMessage(), message);
     }

--- a/src/test/java/me/moodcat/util/InjectTestRule.java
+++ b/src/test/java/me/moodcat/util/InjectTestRule.java
@@ -1,0 +1,47 @@
+package me.moodcat.util;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Type;
+
+import org.junit.rules.MethodRule;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.Statement;
+
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+
+public class InjectTestRule implements MethodRule {
+
+    private final Injector injector;
+
+    public InjectTestRule(final Injector injector) {
+        this.injector = injector;
+    }
+
+    @Override
+    public Statement apply(final Statement base, final FrameworkMethod method, final Object target) {
+        return new Statement() {
+
+            @Override
+            public void evaluate() throws Throwable {
+                injectFields(target);
+                base.evaluate();
+            }
+
+        };
+    }
+
+    private void injectFields(final Object target) throws IllegalAccessException {
+        Class<?> clasz = target.getClass();
+        for (Field field : clasz.getDeclaredFields()) {
+            Inject inject = field.getAnnotation(Inject.class);
+            if (inject != null) {
+                field.setAccessible(true);
+                Type type = field.getGenericType();
+                field.set(target, injector.getInstance(Key.get(type)));
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
- Managed to shrink the e2e tests with 50 lines. Imo a bit more readable this way.
- Added an injection test rule that allows to inject Moodcat objects (DAO's, backends) into e2e tests.
