### PR TITLE
Replaced Cobertura with Jacoco as Testing coverage engine

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,11 +61,11 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
 		<checkstyle.version>2.15</checkstyle.version>
-		<cobertura.version>2.7</cobertura.version>
 		<findbugs.version>3.0.1</findbugs.version>
 		<guice.version>3.0</guice.version>
 		<hibernate.version>4.3.8.Final</hibernate.version>
 		<jackson.version>2.4.4</jackson.version>
+		<jacoco.version>0.7.5.201505241946</jacoco.version>
 		<jetty.version>9.2.10.v20150310</jetty.version>
 		<junit.version>4.12</junit.version>
 		<logback.version>1.0.13</logback.version>
@@ -367,27 +367,7 @@
 				</configuration>
 			</plugin>
 
-			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>cobertura-maven-plugin</artifactId>
-				<version>${cobertura.version}</version>
-				<dependencies>
-					<dependency>
-						<groupId>org.ow2.asm</groupId>
-						<artifactId>asm</artifactId>
-						<version>5.0.3</version>
-					</dependency>
-				</dependencies>
-				<configuration>
-					<instrumentation>
-						<excludes>
-							<exclude>me/moodcat/database/bulkInsert/*.class</exclude>
-						</excludes>
-					</instrumentation>
-				</configuration>
-			</plugin>
-
-			<!-- The Lombok plugin compiles lombok annotations to the target/generated-sources 
+            <!-- The Lombok plugin compiles lombok annotations to the target/generated-sources
 				folder so that they can be used for static analysis -->
 			<plugin>
 				<groupId>org.projectlombok</groupId>
@@ -449,6 +429,19 @@
 					</archive>
 				</configuration>
 			</plugin>
+
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
 
 		</plugins>
 	</build>
@@ -513,19 +506,6 @@
 			</plugin>
 
 			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>cobertura-maven-plugin</artifactId>
-				<version>${cobertura.version}</version>
-				<configuration>
-					<instrumentation>
-						<excludes>
-							<exclude>me/moodcat/database/bulkInsert/*.class</exclude>
-						</excludes>
-					</instrumentation>
-				</configuration>
-			</plugin>
-
-			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-pmd-plugin</artifactId>
 				<version>${pmd.version}</version>
@@ -545,6 +525,13 @@
 				<configuration>
 					<failOnError>false</failOnError>
 				</configuration>
+			</plugin>
+
+			<!-- Coverage -->
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>${jacoco.version}</version>
 			</plugin>
 
 		</plugins>


### PR DESCRIPTION
Cobertura spams a lot during `mvn site` due to it's incapability of parsing Java 8 source code.
Jacoco does the same as Cobertura, but actually works ;p (and in my eyes looks better too).
